### PR TITLE
workflows: dep updates and Syft install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,16 +220,16 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.CI_USERNAME }}
@@ -268,13 +268,13 @@ jobs:
 
       - name: Install Syft for sboms
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sudo sh -s -- -b /usr/local/bin
         shell: bash
 
       - name: Import GPG key
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.CALYPTIA_GPG_KEY }}
           passphrase: ${{ secrets.CALYPTIA_GPG_KEY_PASSPHRASE }}
@@ -289,13 +289,13 @@ jobs:
 
       - name: Run GoReleaser
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           distribution: goreleaser-pro
-          args: release --skip-validate --clean
+          args: release --skip=validate --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.CI_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_KEY }}
 

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ _download_url() {
   fi
 
   _download_trailedVersion="$(echo "$_download_version" | tr -d v)"
-  echo "https://github.com/chronosphereio/calyptia-cli/releases/download/${_download_version}/cli_${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
+  echo "https://github.com/chronosphereio/calyptia-cli/releases/download/${_download_version}/calyptia-cli_${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
 }
 
 echo "Downloading Calyptia CLI from URL: $(_download_url)"

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ _download_url() {
   _download_os="$(_detect_os)"
   # shellcheck disable=SC2154
   _download_version="$cli_VERSION"
+  _download_artefact_prefix="${cli_ARTEFACT_PREFIX:-calyptia-cli}"
 
   # releases should be prefixed with `v`
   case "$_download_version" in
@@ -70,7 +71,7 @@ _download_url() {
   fi
 
   _download_trailedVersion="$(echo "$_download_version" | tr -d v)"
-  echo "https://github.com/chronosphereio/calyptia-cli/releases/download/${_download_version}/calyptia-cli_${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
+  echo "https://github.com/chronosphereio/calyptia-cli/releases/download/${_download_version}/${_download_artefact_prefix}_${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
 }
 
 echo "Downloading Calyptia CLI from URL: $(_download_url)"


### PR DESCRIPTION
Resolve issues with release process and dep updates for actions.
Fixes install script failure with old name.

```
...
curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
  
[info] fetching release script for tag='v0.105.0' 
[info] using release tag='v0.105.0' version='0.105.0' os='linux' arch='amd64' 
install: cannot create regular file '/usr/local/bin/syft': Permission denied
Error:  failed to install syft 
...
  • DEPRECATED: --skip-validate was deprecated in favor of --skip=validate, check https://goreleaser.com/deprecations#-skip for more details
```


