### PR TITLE
[sc-86730]: Remove explicit workflow for CodeQL checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,17 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Markdownlint
     steps:
+      - uses: actions/checkout@v4
       - name: Run markdownlint
         uses: actionshub/markdownlint@v3.1.4
-
-  golint-pr:
-    runs-on: ubuntu-latest
-    name: PR - GO lint
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          go_version: "1.21"
-          golangci_lint_flags: "--timeout=10m"


### PR DESCRIPTION
As per discussion in [sc-86730], removing explicit CodeQL workflow as already configured by repository set up.
Also fixing MarkdownLint as never checked out the code itself so nothing to lint!