### PR TITLE
[sc-84760]: add local traffic policy option to CLI

### DIFF
--- a/cmd/operator/install_test.go
+++ b/cmd/operator/install_test.go
@@ -49,6 +49,7 @@ func TestPrepareManifest(t *testing.T) {
 	coreInstanceVersion := "v1.0.0"
 	coreDockerImage := "calyptia/core-operator"
 	namespace := "my-namespace"
+	enableExternalTrafficPolicyLocal := true
 	const deploymentManifest string = `
 apiVersion: v1
 kind: Namespace
@@ -91,6 +92,7 @@ spec:
       containers:
       - command:
         - /manager
+        args: []
         image: ghcr.io/calyptia/core-operator:v1.0.0-RC1
         livenessProbe:
           httpGet:
@@ -130,7 +132,7 @@ spec:
 		}
 
 		// Test the prepareManifest function
-		resultFile, err := prepareInstallManifest(coreInstanceVersion, coreDockerImage, namespace, false)
+		resultFile, err := prepareInstallManifest(coreInstanceVersion, coreDockerImage, namespace, false, enableExternalTrafficPolicyLocal)
 		// Verify the results
 		if err != nil {
 			t.Errorf("Expected no error, but got: %v", err)
@@ -144,6 +146,9 @@ spec:
 		}
 		if strings.Contains(result, fmt.Sprintf("namespace: %s", namespace)) == false {
 			t.Errorf("Expected namespace: %s, but got: %s", namespace, result)
+		}
+		if strings.Contains(result, "args: ['"+EnableExternalTrafficPolicyLocal+"']") == false {
+			t.Errorf("Expected args: %s, but got: %s", EnableExternalTrafficPolicyLocal, result)
 		}
 
 		// Clean up the temporary file

--- a/cmd/operator/manifest.yaml
+++ b/cmd/operator/manifest.yaml
@@ -963,6 +963,7 @@ spec:
       - command:
         - /manager
         image: ghcr.io/calyptia/core-operator:v2.8.0
+        args: []
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -28,10 +28,11 @@ const (
 
 func NewCmdUpdate() *cobra.Command {
 	var (
-		coreOperatorVersion string
-		waitReady           bool
-		waitTimeout         time.Duration
-		verbose             bool
+		coreOperatorVersion        string
+		waitReady                  bool
+		waitTimeout                time.Duration
+		verbose                    bool
+		externalTrafficPolicyLocal bool
 	)
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -109,7 +110,7 @@ func NewCmdUpdate() *cobra.Command {
 				coreOperatorVersion = utils.DefaultCoreOperatorDockerImageTag
 			}
 
-			manifest, err := installManifest(namespace, utils.DefaultCoreOperatorDockerImage, coreOperatorVersion, k8serrors.IsNotFound(err))
+			manifest, err := installManifest(namespace, utils.DefaultCoreOperatorDockerImage, coreOperatorVersion, k8serrors.IsNotFound(err), externalTrafficPolicyLocal)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Simplified version of #781 to reduce the impact, I agree we should have better YAML handling but not sure we should also do all that in a single PR. This tries to follow the existing simple string replacement approach.

No need to expose this to helm charts, it is only required for the package installation on K3S.