### PR TITLE
[sc-86134]: fix operator args

### DIFF
--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -33,7 +33,7 @@ import (
 var f embed.FS
 
 const manifestFile = "manifest.yaml"
-const EnableExternalTrafficPolicyLocal = "enable-external-traffic-policy-local"
+const EnableExternalTrafficPolicyLocal = "-enable-external-traffic-policy-local=true"
 
 func NewCmdInstall() *cobra.Command {
 	var (

--- a/cmd/operator/install.go
+++ b/cmd/operator/install.go
@@ -275,6 +275,7 @@ func injectNamespace(s string, namespace string) string {
 
 func injectArguments(s string, externalTrafficPolicyLocal bool) string {
 	if externalTrafficPolicyLocal {
+		fmt.Println("Enabling traffic policy LOCAL: ", EnableExternalTrafficPolicyLocal)
 		return strings.ReplaceAll(s, "args: []", "args: ['"+EnableExternalTrafficPolicyLocal+"']")
 	}
 	return s

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -142,6 +142,7 @@ func NewCmdUpdate() *cobra.Command {
 	fs.DurationVar(&waitTimeout, "timeout", defaultWaitTimeout, "Wait timeout")
 	fs.BoolVar(&verbose, "verbose", false, "Print verbose command output")
 	fs.StringVar(&coreOperatorVersion, "version", "", "Core instance version")
+	fs.BoolVar(&externalTrafficPolicyLocal, "external-traffic-policy-local", false, "Set ExternalTrafficPolicy to local for all services used by core operator pipelines.")
 	_ = cmd.Flags().MarkHidden("image")
 	clientcmd.BindOverrideFlags(configOverrides, fs, clientcmd.RecommendedConfigOverrideFlags("kube-"))
 


### PR DESCRIPTION
Incorrect operator arguments mean it is not setting the right traffic policy and blocking https://github.com/chronosphereio/calyptia-core-packages/pull/333

Also fixed missing update inclusion and added basic logging of this feature being enabled.

Raised a separate improvement story on logging to help with future updates.


