### PR TITLE
Revert removal of args support

### DIFF
--- a/cmd/operator/manifest.yaml
+++ b/cmd/operator/manifest.yaml
@@ -971,6 +971,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
+        args: []
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
Auto update PR inadvertently removed args support which breaks source-ip injection for K3S packages: https://github.com/chronosphereio/calyptia-cli/pull/798/files

We need to push a release up to resolve issues found in tests here: https://github.com/chronosphereio/calyptia-core-packages/pull/335
