### PR TITLE
Optimise and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      
+      # Required for goreleaser cross-compilation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -247,7 +251,7 @@ jobs:
 
       - name: Set up PR build
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "goreleaser-flags=--skip-publish --skip-sign --skip-sbom --snapshot" >> $GITHUB_ENV
+        run: echo 'goreleaser-flags=--skip=publish --skip=sign --skip=sbom --snapshot' >> $GITHUB_ENV
 
       - name: Run GoReleaser with flags
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,14 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_KEY }}
 
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artefacts
+          path: dist/**/*.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+
   update-core-product-release:
     name: Push new version to core-product-release
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=main,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=sha
           labels: |
             org.opencontainers.image.title="chronosphereio/calyptia-cli" \
             org.opencontainers.image.description="Calyptia Core CLI" \
@@ -207,9 +209,7 @@ jobs:
   release:
     name: Release the artefacts
     permissions:
-      contents: write
-      packages: write
-    if: ${{ github.event_name != 'pull_request' }}
+      contents: read
     runs-on: ubuntu-latest-m
     steps:
       - name: Checkout
@@ -222,57 +222,11 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.CI_USERNAME }}
-          password: ${{ secrets.CI_PAT }}
-
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-          export_environment_variables: true
-          create_credentials_file: true
-
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
-
-      - name: Extract image metadata
-        id: meta-github-image
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=main,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=sha,prefix=,suffix=,format=short
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          target: production
-          platforms: linux/amd64, linux/arm64
-          provenance: false
-          push: true
-          tags: ${{ steps.meta-github-image.outputs.tags }}
-          labels: ${{ steps.meta-github-image.outputs.labels }}
-
       - name: Install Syft for sboms
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sudo sh -s -- -b /usr/local/bin
         shell: bash
 
       - name: Import GPG key
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
@@ -280,21 +234,29 @@ jobs:
           passphrase: ${{ secrets.CALYPTIA_GPG_KEY_PASSPHRASE }}
 
       - name: Update the upx version
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           curl --silent -L https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-arm64_linux.tar.xz | tar -xJf - upx-4.1.0-arm64_linux/upx -O > upx
           sudo mv upx /bin/
           sudo chmod a+x /bin/upx
         shell: bash
 
-      - name: Run GoReleaser
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: goreleaser/goreleaser-action@v5
+      # Note snapshot removal in v4: https://github.com/caarlos0/goreleaser-action-v4-auto-snapshot-example
+      - name: Set up snapshot build
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "goreleaser-flags=--snapshot" >> $GITHUB_ENV
+
+      - name: Set up PR build
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "goreleaser-flags=--skip-publish --skip-sign --skip-sbom --snapshot" >> $GITHUB_ENV
+
+      - name: Run GoReleaser with flags
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           distribution: goreleaser-pro
-          args: release --skip=validate --clean
+          args: release --skip=validate --clean ${{ env.goreleaser-flags }}
         env:
+          # Require this for brew recipe update
           GITHUB_TOKEN: ${{ secrets.CI_PAT }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,4 +32,4 @@ brews:
     repository:
       owner: chronosphereio
       name: calyptia-homebrew-tap
-    folder: Formula
+    directory: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
+      - windows_arm64
 
 universal_binaries:
   - replace: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,8 @@ builds:
 
 universal_binaries:
   - replace: true
+    id: calyptia
+    name_template: calyptia
 
 brews:
   - name: calyptia

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,9 +29,15 @@ universal_binaries:
 
 brews:
   - name: calyptia
+    alternative_names:
+      - calyptia@{{ .Version }}
+      - calyptia@{{ .Major }}
     description: Calyptia Cloud CLI
     homepage: https://github.com/chronosphereio/calyptia-cli
     repository:
       owner: chronosphereio
       name: calyptia-homebrew-tap
     directory: Formula
+    license: Apache-2.0
+    test: |
+          system "#{bin}/calyptia version"


### PR DESCRIPTION
Releases are currently building containers twice which takes an age for the ARM ones on an AMD host so removed that.
No GCP access required anymore (used to push to a bucket) so removed that.
Running the GoReleaser step on all CI but with configurable flags, this will verify it prior to release then as well.

Update GoReleaser config to correctly handle universal binaries and also add some extra info for the brew recipe.

Added Windows ARM 64 build as well.
Updated install script to support more options and cope with non-zero root users or similar sudo stuff.
