### PR TITLE
passing skip-service-creation into sync

### DIFF
--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -280,7 +280,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				}
 				coreDockerFromCloudImage = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorFromCloudDockerImage, coreDockerFromCloudImageTag)
 			}
-			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, !noTLSVerify, httpProxy, httpsProxy, created, serviceAccount.Name)
+			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, skipServiceCreation, !noTLSVerify, httpProxy, httpsProxy, created, serviceAccount.Name)
 			if err != nil {
 				if err := config.Cloud.DeleteCoreInstance(ctx, created.ID); err != nil {
 					return fmt.Errorf("failed to rollback created core instance %v", err)

--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -140,7 +140,7 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 
 				label := fmt.Sprintf("%s=%s", k8s.LabelInstance, coreInstanceKey)
 				cmd.Printf("Waiting for core-instance to update...\n")
-				if err := k8sClient.UpdateSyncDeploymentByLabel(ctx, label, newVersion, strconv.FormatBool(!noTLSVerify), verbose, waitTimeout); err != nil {
+				if err := k8sClient.UpdateSyncDeploymentByLabel(ctx, label, newVersion, strconv.FormatBool(!noTLSVerify), skipServiceCreation, verbose, waitTimeout); err != nil {
 					if !verbose {
 						return fmt.Errorf("could not update core-instance to version %s for extra details use --verbose flag", newVersion)
 					}

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -287,7 +287,7 @@ func TestUpdateSyncDeploymentByLabel(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			label := fmt.Sprintf("%s=%s,%s=%s,%s=%s", LabelComponent, "operator", LabelCreatedBy, "calyptia-cli", LabelAggregatorID, tc.aggID)
 
-			if err := tc.client.UpdateSyncDeploymentByLabel(context.TODO(), label, fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorDockerImage, "1234"), "true", false, time.Minute); err != nil && !tc.expectErr {
+			if err := tc.client.UpdateSyncDeploymentByLabel(context.TODO(), label, fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorDockerImage, "1234"), "true", false, false, time.Minute); err != nil && !tc.expectErr {
 				t.Errorf("failed to find deployment by label %s", err)
 			}
 		})


### PR DESCRIPTION
# Summary of this proposal
passing skip-service-creation into sync
[sc-92924](https://app.shortcut.com/chronosphere/story/92924/ability-to-set-a-static-service-name-for-a-pipeline-in-calyptia)


```
~/calyptia-cli# calyptia create core_instance operator --name test --skip-service-creation
Found calyptia core operator installed, version: v2.12.0...
Core instance created successfully
Deployed images=(sync-to-cloud: ghcr.io/calyptia/core-operator/sync-to-cloud:v2.12.0, sync-from-cloud: ghcr.io/calyptia/core-operator/sync-from-cloud:v2.12.0)
Resources created:
Deployment=calyptia-test-default-sync
Secret=calyptia-test-default-secret
ClusterRole=calyptia-test-default-cluster-role
ClusterRoleBinding=calyptia-test-default-cluster-role-binding
ServiceAccount=calyptia-test-default-service-account

~/calyptia-cli# kubectl get pipeline 
NAME                     STATUS
health-check-6bd3-ewxj   STARTING

~/calyptia-cli# kubectl get svc 
NAME                                               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
kubernetes                                         ClusterIP   10.43.0.1       <none>        443/TCP    73s
calyptia-core-controller-manager-metrics-service   ClusterIP   10.43.113.114   <none>        8443/TCP   50s
```
