### PR TITLE
interactive update operator warning

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -20,11 +20,11 @@ const (
 
 	DefaultCoreOperatorToCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-to-cloud"
 	// DefaultCoreOperatorToCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorToCloudDockerImageTag = "v2.12.1"
+	DefaultCoreOperatorToCloudDockerImageTag = "v2.12.0"
 
 	DefaultCoreOperatorFromCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-from-cloud"
 	// DefaultCoreOperatorFromCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorFromCloudDockerImageTag = "v2.12.1"
+	DefaultCoreOperatorFromCloudDockerImageTag = "v2.12.0"
 )
 
 type RecordCell struct {


### PR DESCRIPTION
# Summary of this proposal

[sc-93553](https://app.shortcut.com/chronosphere/story/93553/calyptia-cli-update-process)

When updating with outdated CLI following Warning message will be printed:

```
# calyptia update operator --kube-namespace calyptia 
Warning: Current version 2.12.0 is less than the latest version 2.12.1
To ensure that the operator functions as intended please install latest version of the CLI, and run "calyptia update operator"
Do you want to proceed with update? (y/N)
n
Error: Aborted
exit status 1
```

Otherwise
```
# calyptia update operator --kube-namespace calyptia 
customresourcedefinition.apiextensions.k8s.io/ingestchecks.core.calyptia.com unchanged
customresourcedefinition.apiextensions.k8s.io/pipelines.core.calyptia.com unchanged
serviceaccount/calyptia-core-controller-manager unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-manager-role configured
clusterrole.rbac.authorization.k8s.io/calyptia-core-metrics-reader unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-pod-role unchanged
clusterrole.rbac.authorization.k8s.io/calyptia-core-proxy-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-manager-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/calyptia-core-proxy-rolebinding unchanged
service/calyptia-core-controller-manager-metrics-service unchanged
deployment.apps/calyptia-core-controller-manager configured
Core operator manager successfully updated to version v2.12.1
```

Update can be forced by passing parameter `--force -f` to the command