### PR TITLE
adding no-proxy, http-proxy and https-proxy to CLI core_instance update

### DIFF
--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -43,7 +43,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 		waitTimeout                    time.Duration
 		noTLSVerify                    bool
 		metricsPort                    string
-		httpProxy, httpsProxy          string
+		httpProxy, httpsProxy, noProxy string
 		memoryLimit                    string
 		annotations                    string
 		tolerations                    string
@@ -280,7 +280,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				}
 				coreDockerFromCloudImage = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorFromCloudDockerImage, coreDockerFromCloudImageTag)
 			}
-			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, skipServiceCreation, !noTLSVerify, httpProxy, httpsProxy, created, serviceAccount.Name)
+			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, skipServiceCreation, !noTLSVerify, httpProxy, httpsProxy, noProxy, created, serviceAccount.Name)
 			if err != nil {
 				if err := config.Cloud.DeleteCoreInstance(ctx, created.ID); err != nil {
 					return fmt.Errorf("failed to rollback created core instance %v", err)
@@ -353,7 +353,8 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 	fs.StringVar(&memoryLimit, "memory-limit", "512Mi", "Minimum memory required")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
 	fs.StringVar(&httpProxy, "http-proxy", "", "http proxy to use on this core instance")
-	fs.StringVar(&httpsProxy, "https-proxy", "", "http proxy to use on this core instance")
+	fs.StringVar(&noProxy, "no-proxy", "", "no proxy to use on this core instance")
+	fs.StringVar(&httpsProxy, "https-proxy", "", "https proxy to use on this core instance")
 	fs.StringVar(&annotations, "annotations", "", "Custom annotations for pipelines. Format should be 'annotation1=value1,annotation2=value2'")
 	fs.StringVar(&tolerations, "tolerations", "", `Custom tolerations for pipelines. Format should be 'key1=Equal:value1:Execute:3600,key2=Exists:value2:NoExecute`)
 

--- a/cmd/coreinstance/create_core_instance_operator.go
+++ b/cmd/coreinstance/create_core_instance_operator.go
@@ -26,27 +26,27 @@ import (
 
 func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernetes.Interface) *cobra.Command {
 	var (
-		coreInstanceName               string
-		coreCloudURL                   string
-		coreFluentBitDockerImage       string
-		coreDockerToCloudImage         string
-		coreDockerFromCloudImage       string
-		noHealthCheckPipeline          bool
-		healthCheckPipelinePort        string
-		healthCheckPipelineServiceType string
-		enableClusterLogging           bool
-		skipServiceCreation            bool
-		environment                    string
-		tags                           []string
-		dryRun                         bool
-		waitReady                      bool
-		waitTimeout                    time.Duration
-		noTLSVerify                    bool
-		metricsPort                    string
-		httpProxy, httpsProxy, noProxy string
-		memoryLimit                    string
-		annotations                    string
-		tolerations                    string
+		coreInstanceName                           string
+		coreCloudURL                               string
+		coreFluentBitDockerImage                   string
+		coreDockerToCloudImage                     string
+		coreDockerFromCloudImage                   string
+		noHealthCheckPipeline                      bool
+		healthCheckPipelinePort                    string
+		healthCheckPipelineServiceType             string
+		enableClusterLogging                       bool
+		skipServiceCreation                        bool
+		environment                                string
+		tags                                       []string
+		dryRun                                     bool
+		waitReady                                  bool
+		waitTimeout                                time.Duration
+		noTLSVerify                                bool
+		metricsPort                                string
+		cloudProxy, httpProxy, httpsProxy, noProxy string
+		memoryLimit                                string
+		annotations                                string
+		tolerations                                string
 	)
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -280,7 +280,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 				}
 				coreDockerFromCloudImage = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorFromCloudDockerImage, coreDockerFromCloudImageTag)
 			}
-			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, skipServiceCreation, !noTLSVerify, httpProxy, httpsProxy, noProxy, created, serviceAccount.Name)
+			syncDeployment, err := k8sClient.DeployCoreOperatorSync(ctx, coreCloudURL, coreDockerFromCloudImage, coreDockerToCloudImage, metricsPort, memoryLimit, annotations, tolerations, skipServiceCreation, !noTLSVerify, cloudProxy, httpProxy, httpsProxy, noProxy, created, serviceAccount.Name)
 			if err != nil {
 				if err := config.Cloud.DeleteCoreInstance(ctx, created.ID); err != nil {
 					return fmt.Errorf("failed to rollback created core instance %v", err)
@@ -352,6 +352,7 @@ func newCmdCreateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 	fs.StringVar(&metricsPort, "metrics-port", "15334", "Port for metrics endpoint.")
 	fs.StringVar(&memoryLimit, "memory-limit", "512Mi", "Minimum memory required")
 	fs.StringVar(&environment, "environment", "", "Calyptia environment name")
+	fs.StringVar(&cloudProxy, "cloud-proxy", "", "proxy for cloud api client to use on this core instance")
 	fs.StringVar(&httpProxy, "http-proxy", "", "http proxy to use on this core instance")
 	fs.StringVar(&noProxy, "no-proxy", "", "no proxy to use on this core instance")
 	fs.StringVar(&httpsProxy, "https-proxy", "", "https proxy to use on this core instance")

--- a/cmd/coreinstance/update_core_instance_operator.go
+++ b/cmd/coreinstance/update_core_instance_operator.go
@@ -23,13 +23,13 @@ import (
 func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernetes.Interface) *cobra.Command {
 	var newVersion, newName, environment string
 	var (
-		disableClusterLogging          bool
-		enableClusterLogging           bool
-		noTLSVerify                    bool
-		skipServiceCreation            bool
-		httpProxy, httpsProxy, noProxy string
-		verbose                        bool
-		waitTimeout                    time.Duration
+		disableClusterLogging                      bool
+		enableClusterLogging                       bool
+		noTLSVerify                                bool
+		skipServiceCreation                        bool
+		cloudProxy, httpProxy, httpsProxy, noProxy string
+		verbose                                    bool
+		waitTimeout                                time.Duration
 	)
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
@@ -144,7 +144,7 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 
 			label := fmt.Sprintf("%s=%s", k8s.LabelInstance, coreInstanceKey)
 			cmd.Printf("Waiting for core-instance to update...\n")
-			if err := k8sClient.UpdateSyncDeploymentByLabel(ctx, label, newVersion, strconv.FormatBool(!noTLSVerify), skipServiceCreation, verbose, httpProxy, httpsProxy, noProxy, waitTimeout); err != nil {
+			if err := k8sClient.UpdateSyncDeploymentByLabel(ctx, label, newVersion, strconv.FormatBool(!noTLSVerify), skipServiceCreation, verbose, cloudProxy, httpProxy, httpsProxy, noProxy, waitTimeout); err != nil {
 				if !verbose {
 					return fmt.Errorf("could not update core-instance to version %s for extra details use --verbose flag", newVersion)
 				}
@@ -167,6 +167,7 @@ func NewCmdUpdateCoreInstanceOperator(config *cfg.Config, testClientSet kubernet
 	fs.BoolVar(&disableClusterLogging, "disable-cluster-logging", false, "Disable cluster logging functionality")
 	fs.BoolVar(&noTLSVerify, "no-tls-verify", false, "Disable TLS verification when connecting to Calyptia Cloud API.")
 	fs.StringVar(&noProxy, "no-proxy", "", "http proxy to use on this core instance")
+	fs.StringVar(&cloudProxy, "cloud-proxy", "", "proxy for cloud api client to use on this core instance")
 	fs.StringVar(&httpProxy, "http-proxy", "", "no proxy to use on this core instance")
 	fs.StringVar(&httpsProxy, "https-proxy", "", "https proxy to use on this core instance")
 	fs.BoolVar(&verbose, "verbose", false, "Print verbose command output")

--- a/cmd/operator/update.go
+++ b/cmd/operator/update.go
@@ -37,7 +37,6 @@ func NewCmdUpdate() *cobra.Command {
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
-
 	cmd := &cobra.Command{
 		Use:     "operator",
 		Aliases: []string{"opr"},

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -49,6 +49,9 @@ const (
 	serviceAccountObjectType      objectType = "service-account"
 	coreTLSVerifyEnvVar           string     = "CORE_TLS_VERIFY"
 	syncTLSVerifyEnvVar           string     = "NO_TLS_VERIFY"
+	syncHttpProxy                 string     = "HTTP_PROXY"
+	syncHttpsProxy                string     = "HTTPS_PROXY"
+	syncNoProxy                   string     = "NO_PROXY"
 	coreSkipServiceCreationEnvVar string     = "CORE_INSTANCE_SKIP_SERVICE_CREATION"
 	defaultOperatorNamespace                 = "calyptia-core"
 	noContainersErrString                    = "no containers found in deployment %s"
@@ -504,7 +507,7 @@ func (client *Client) UpdateDeploymentByLabel(ctx context.Context, label, newIma
 	return nil
 }
 
-func (client *Client) UpdateSyncDeploymentByLabel(ctx context.Context, label, newImage, tlsVerify string, skipServiceCreation, verbose bool, waitTimeout time.Duration) error {
+func (client *Client) UpdateSyncDeploymentByLabel(ctx context.Context, label, newImage, tlsVerify string, skipServiceCreation, verbose bool, httpProxy, httpsProxy, noProxy string, waitTimeout time.Duration) error {
 	deploymentList, err := client.FindDeploymentByLabel(ctx, label)
 	if err != nil {
 		return err
@@ -520,11 +523,17 @@ func (client *Client) UpdateSyncDeploymentByLabel(ctx context.Context, label, ne
 	for i, container := range deployment.Spec.Template.Spec.Containers {
 		if strings.Contains(container.Name, "to-cloud") {
 			deployment.Spec.Template.Spec.Containers[i].Image = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorToCloudDockerImage, newImage)
-			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, tlsVerify)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncTLSVerifyEnvVar, tlsVerify)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncNoProxy, noProxy)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncHttpProxy, httpProxy)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncHttpsProxy, httpsProxy)
 		}
 		if strings.Contains(container.Name, "from-cloud") {
 			deployment.Spec.Template.Spec.Containers[i].Image = fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorFromCloudDockerImage, newImage)
-			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, tlsVerify)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncTLSVerifyEnvVar, tlsVerify)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncNoProxy, noProxy)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncHttpProxy, httpProxy)
+			deployment.Spec.Template.Spec.Containers[i].Env = client.updateEnvVars(container.Env, syncHttpsProxy, httpsProxy)
 			if skipServiceCreation {
 				deployment.Spec.Template.Spec.Containers[i].Env = append(deployment.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
 					Name:  "SKIP_SERVICE_CREATION",
@@ -560,12 +569,12 @@ func (client *Client) rolloutDeployment(ctx context.Context, namespace, deployme
 	return err
 }
 
-func (client *Client) updateEnvVars(envVars []corev1.EnvVar, tlsVerify string) []corev1.EnvVar {
+func (client *Client) updateEnvVars(envVars []corev1.EnvVar, key, value string) []corev1.EnvVar {
 	found := false
 	for idx, envVar := range envVars {
-		if envVar.Name == syncTLSVerifyEnvVar {
-			if envVar.Value != tlsVerify {
-				envVars[idx].Value = tlsVerify
+		if envVar.Name == key {
+			if envVar.Value != value {
+				envVars[idx].Value = value
 			}
 			found = true
 		}
@@ -573,8 +582,8 @@ func (client *Client) updateEnvVars(envVars []corev1.EnvVar, tlsVerify string) [
 
 	if !found {
 		envVars = append(envVars, corev1.EnvVar{
-			Name:  coreTLSVerifyEnvVar,
-			Value: tlsVerify,
+			Name:  key,
+			Value: value,
 		})
 	}
 
@@ -622,7 +631,7 @@ func (client *Client) FindDeploymentByLabel(ctx context.Context, label string) (
 	return client.AppsV1().Deployments(client.Namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 }
 
-func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, fromCloudImage, toCloudImage string, metricsPort string, memoryLimit string, annotations string, tolerations string, skipServiceCreation, noTLSVerify bool, httpProxy, httpsProxy string, coreInstance cloud.CreatedCoreInstance, serviceAccount string) (*appsv1.Deployment, error) {
+func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, fromCloudImage, toCloudImage string, metricsPort string, memoryLimit string, annotations string, tolerations string, skipServiceCreation, noTLSVerify bool, httpProxy, httpsProxy, noProxy string, coreInstance cloud.CreatedCoreInstance, serviceAccount string) (*appsv1.Deployment, error) {
 	podTolerations, err := validateTolerations(tolerations)
 	if err != nil {
 		return nil, err
@@ -657,6 +666,10 @@ func (client *Client) DeployCoreOperatorSync(ctx context.Context, coreCloudURL, 
 		{
 			Name:  "METRICS_PORT",
 			Value: metricsPort,
+		},
+		{
+			Name:  "NO_PROXY",
+			Value: noProxy,
 		},
 		{
 			Name:  "HTTP_PROXY",

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -287,7 +287,7 @@ func TestUpdateSyncDeploymentByLabel(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			label := fmt.Sprintf("%s=%s,%s=%s,%s=%s", LabelComponent, "operator", LabelCreatedBy, "calyptia-cli", LabelAggregatorID, tc.aggID)
 
-			if err := tc.client.UpdateSyncDeploymentByLabel(context.TODO(), label, fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorDockerImage, "1234"), "true", false, false, time.Minute); err != nil && !tc.expectErr {
+			if err := tc.client.UpdateSyncDeploymentByLabel(context.TODO(), label, fmt.Sprintf("%s:%s", utils.DefaultCoreOperatorDockerImage, "1234"), "true", false, false, "", "", "", "", time.Minute); err != nil && !tc.expectErr {
 				t.Errorf("failed to find deployment by label %s", err)
 			}
 		})


### PR DESCRIPTION
# Summary of this proposal

adding no-proxy, http-proxy and https-proxy to CLI core_instance update

[sc-93807](https://app.shortcut.com/chronosphere/story/93807/cli-update-http-proxy-https-proxy-and-no-proxy)
[sc-93976](https://app.shortcut.com/chronosphere/story/93976/ability-to-configure-proxy-for-both-inbound-and-outbound-traffic)