### PR TITLE
Fix macOS download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,8 +111,8 @@ _download_binary() {
   fi
 
   # If we do not have it yet then use the arch version
-  echo "Downloading from URL:  ${_download_url_prefix}${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
-  curl  --progress-bar --output "$_download_output_dir"/cli.tar.gz -SLf "${_download_url_prefix}${_download_trailedVersion}_${_download_os}_${_download_arch}.tar.gz"
+  echo "Downloading from URL:  $_url"
+  curl  --progress-bar --output "$_download_output_dir"/cli.tar.gz -SLf "$_url"
   tar -C "$_download_output_dir" -xzf cli.tar.gz calyptia
   rm -f "$_download_output_dir"/cli.tar.gz
 }


### PR DESCRIPTION
Missing URL usage for new macOS single binary install.

Tested locally on macOS:
```
$ ./install.sh 
Downloading from URL:  https://github.com/chronosphereio/calyptia-cli/releases/download/v1.19.0/calyptia-cli_1.19.0_darwin_all.tar.gz
######################################################################################################################################################################################################################## 100.0%
Sudo rights are needed to move the binary to /usr/local/bin, please type your password when asked
Password:
Calyptia CLI installed in /usr/local/bin
$ calyptia version
1.19.0
```

Tested on centos container:
```
$ docker run --rm -it -v ./install.sh:/install.sh:ro centos 
Unable to find image 'centos:latest' locally
latest: Pulling from library/centos
52f9ef134af7: Already exists 
Digest: sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
Status: Downloaded newer image for centos:latest
[root@18eae5cf02df /]# /install.sh 
WARNING: missing sudo command, may be required to elevate permissions so please install or run with relevant permissions
Downloading from URL:  https://github.com/chronosphereio/calyptia-cli/releases/download/v1.19.0/calyptia-cli_1.19.0_linux_arm64.tar.gz
######################################################################################################################################################################################################################## 100.0%
Calyptia CLI installed in /usr/local/bin
[root@18eae5cf02df /]# calyptia version
1.19.0
```


