### PR TITLE
bumping to 2.12.8

### DIFF
--- a/cmd/operator/manifest.yaml
+++ b/cmd/operator/manifest.yaml
@@ -1655,7 +1655,7 @@ spec:
       - args: []
         command:
         - /manager
-        image: ghcr.io/calyptia/core-operator:v2.12.7
+        image: ghcr.io/calyptia/core-operator:v2.12.8
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -16,15 +16,15 @@ const (
 
 	DefaultCoreOperatorDockerImage = "ghcr.io/calyptia/core-operator"
 	// DefaultCoreOperatorDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorDockerImageTag = "v2.12.7"
+	DefaultCoreOperatorDockerImageTag = "v2.12.8"
 
 	DefaultCoreOperatorToCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-to-cloud"
 	// DefaultCoreOperatorToCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorToCloudDockerImageTag = "v2.12.7"
+	DefaultCoreOperatorToCloudDockerImageTag = "v2.12.8"
 
 	DefaultCoreOperatorFromCloudDockerImage = "ghcr.io/calyptia/core-operator/sync-from-cloud"
 	// DefaultCoreOperatorFromCloudDockerImageTag not manually modified, CI should switch this version on every new release.
-	DefaultCoreOperatorFromCloudDockerImageTag = "v2.12.7"
+	DefaultCoreOperatorFromCloudDockerImageTag = "v2.12.8"
 )
 
 type RecordCell struct {


### PR DESCRIPTION
for some reason previous operator release didn't bump versions accordingly so I'm doing it manually